### PR TITLE
feat: make ble name configuranble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
 .DS_Store
+build/

--- a/scripts/add-config.py
+++ b/scripts/add-config.py
@@ -14,11 +14,10 @@ def main():
     cfg = sys.argv[1]
 
     base = os.path.dirname(os.path.realpath(__file__))
-    binary = os.path.join(base, "../sketches/BLE_Scratch/build/arduino.mbed_nano.nano33ble/BLE_Scratch.ino.with_bootloader.bin")
+    binary = os.path.join(base, "../sketches/BLE_Scratch/build/arduino.mbed_nano.nano33ble/BLE_Scratch.ino.bin")
     new_name = binary+".cfg.bin"
     
     with open(binary, 'rb') as f1:
-        f1.seek(0)
         with open(new_name, 'wb') as f2:
             f2.write(f1.read())
             f2.write(header)

--- a/scripts/add-config.py
+++ b/scripts/add-config.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import sys, os
+
+header = bytes([0x8a, 0x48, 0x92, 0xdf, 0xaa, 0x69, 0x5c, 0x41])
+magic = bytes([0x7F])
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: add-config.py <config>")
+        sys.exit(1)
+
+    cfg = sys.argv[1]
+
+    base = os.path.dirname(os.path.realpath(__file__))
+    binary = os.path.join(base, "../sketches/BLE_Scratch/build/arduino.mbed_nano.nano33ble/BLE_Scratch.ino.with_bootloader.bin")
+    new_name = binary+".cfg.bin"
+    
+    with open(binary, 'rb') as f1:
+        f1.seek(0)
+        with open(new_name, 'wb') as f2:
+            f2.write(f1.read())
+            f2.write(header)
+            f2.write(magic)
+            f2.write(len(cfg).to_bytes(1, byteorder='little'))
+            f2.write(cfg.encode("ascii"))
+
+    print("Attached", cfg, "to", new_name)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -4,4 +4,4 @@ set -xe
 
 base=$(dirname "$0")
 
-arduino-cli compile -b arduino:mbed_nano:nano33ble -e "$base/../sketches/BLE_Scratch/BLE_Scratch.ino"
+arduino-cli -v compile -b arduino:mbed_nano:nano33ble -e "$base/../sketches/BLE_Scratch/BLE_Scratch.ino"

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -xe
+
+base=$(dirname "$0")
+
+arduino-cli compile -b arduino:mbed_nano:nano33ble -e "$base/../sketches/BLE_Scratch/BLE_Scratch.ino"

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -xe
+
+base=$(dirname "$0")
+binary="$base/../sketches/BLE_Scratch/build/arduino.mbed_nano.nano33ble/BLE_Scratch.ino.with_bootloader.bin.cfg.bin"
+
+port=$(arduino-cli board list | grep "arduino:mbed_nano:nano33ble" | awk '{print $1}' | head -n 1)
+
+arduino-cli upload -v \
+    -i "$binary" \
+    -b arduino:mbed_nano:nano33ble \
+    -p "$port"

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -3,7 +3,7 @@
 set -xe
 
 base=$(dirname "$0")
-binary="$base/../sketches/BLE_Scratch/build/arduino.mbed_nano.nano33ble/BLE_Scratch.ino.with_bootloader.bin.cfg.bin"
+binary="$base/../sketches/BLE_Scratch/build/arduino.mbed_nano.nano33ble/BLE_Scratch.ino.bin.cfg.bin"
 
 port=$(arduino-cli board list | grep "arduino:mbed_nano:nano33ble" | awk '{print $1}' | head -n 1)
 

--- a/sketches/BLE_Scratch/BLE_Scratch.ino
+++ b/sketches/BLE_Scratch/BLE_Scratch.ino
@@ -41,6 +41,7 @@
 const int VERSION = 0x00000000;
 const uint8_t HEADER[] = {0x8a, 0x48, 0x92, 0xdf, 0xaa, 0x69, 0x5c, 0x41};
 const uint8_t MAGIC = 0x7F;
+const uint8_t MEMORY_SIZE = 256000;
 
 BLEService                     service                       (BLE_SENSE_UUID("0000"));
 BLEUnsignedIntCharacteristic   versionCharacteristic         (BLE_SENSE_UUID("1001"), BLERead);
@@ -59,49 +60,51 @@ int delayTime = 10;
 int red = 0, green = 0, blue = 0, ambientLight = 0;
 int proximity = 255;
 
-uint32_t search_in_mem(uint32_t const start, uint32_t const end,
-                       const uint8_t *buff, const int size) {
-  for (int i = 0; i <= end - size; i++) {
-    auto p = start + i;
-    if (memcmp(reinterpret_cast<const void *>(p), buff, size) == 0) {
-      return p;
-    }
+void printSerialMsg(const char * msg) {
+  if (Serial) {
+    Serial.println(msg);
   }
-
-  return 0;
 }
 
-uint32_t get_config_bytes(uint8_t *buff, uint32_t) {
-  for (uint32_t addr = 0; addr < 0x40000;) {
-    auto found = search_in_mem(addr, 0x40000, HEADER, sizeof(HEADER));
-    if (found != 0) {
-#ifdef DEBUG
-      Serial.println("Found header");
-#endif
-      uint8_t magic = *reinterpret_cast<uint8_t *>(found + sizeof(HEADER));
-      if (magic == MAGIC) {
-#ifdef DEBUG
-        Serial.println("Found magic");
-#endif
-
-        uint8_t size = *reinterpret_cast<uint8_t *>(found + sizeof(HEADER) + 1);
-        memcpy(buff, reinterpret_cast<void *>(found + sizeof(HEADER) + 2),
-               size);
-
-        return size;
+uint32_t get_config_bytes(uint8_t *buff, const uint32_t n) {
+  auto search_in_mem = [](const uint32_t start, const uint32_t end, const uint8_t *buff, const int size) -> uint32_t {
+    for (int i = 0; i <= end - size; i++) {
+      auto p = start + i;
+      if (memcmp(reinterpret_cast<const void *>(p), buff, size) == 0) {
+        return p;
       }
     }
+
+    return 0;
+  };
+
+  uint32_t addr = 0;
+
+  while(1){
+    auto found = search_in_mem(addr, MEMORY_SIZE, HEADER, sizeof(HEADER));
+    if (found == 0){
+      printSerialMsg("config header not founded");
+      return 0;
+    }
+    printSerialMsg("config header founded");
+    
+    uint8_t magic = *reinterpret_cast<uint8_t *>(found + sizeof(HEADER));
+    if (magic == MAGIC) {
+      printSerialMsg("config magic number founded");
+    
+      uint8_t size = *reinterpret_cast<uint8_t *>(found + sizeof(HEADER) + 1);
+      memcpy(buff, reinterpret_cast<void *>(found + sizeof(HEADER) + 2), min(size, n));
+
+      return size;
+    }
+    
     addr = found + sizeof(HEADER);
   }
 
   return 0;
 }
 
-void printSerialMsg(const char * msg) {
-  if (Serial) {
-    Serial.println(msg);
-  }
-}
+
 
 void setup() {
   Serial.begin(9600);
@@ -174,7 +177,7 @@ if (!APDS.begin()) {
   address.toUpperCase();
 
   name = "BLESense-";
-  if (userName) {
+  if (userName != "") {
     name += userName;
   } else {
     name += address[address.length() - 5];

--- a/sketches/BLE_Scratch/BLE_Scratch.ino
+++ b/sketches/BLE_Scratch/BLE_Scratch.ino
@@ -4,12 +4,12 @@
 
 // Uncomment one of these defines to select which board you are using
 
-//#define ARDUINO_NANO_BLE_SENSE
+#define ARDUINO_NANO_BLE_SENSE
 //#define ARDUINO_NANO_BLE
-#define ARDUINO_NANO_BLE_SENSE_R2
+//#define ARDUINO_NANO_BLE_SENSE_R2
 
 // when this is defined the board will print debug messages on serial
-#define DEBUG
+//#define DEBUG
 
 
 


### PR DESCRIPTION
Add the ability to pass the BLE device name in the binary. 
The configuration can be appended at the end of the compiled binary with the Python script `add-config.py`.

To use the new feature, there is a set of utilities in the `./scripts` folder. 

You can do the following:

1. run the compilation with `./scripts/compile.sh`
2. add the config name with the python script `add-config.py`, i.e., `./scripts/add-config.py <your-name>`
3. upload the new binary with the `./scripts/upload.sh`