### PR TITLE
chore: add publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
             args: "--target aarch64-apple-darwin"
           - platform: "macos-latest" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
-          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+          - platform: "ubuntu-20.04" # for Tauri v2 you could replace this with ubuntu-22.04.
             args: ""
           - platform: "windows-latest"
             args: ""
@@ -42,7 +42,7 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        if: matrix.platform == 'ubuntu-20.04' # This must match the platform value defined above.
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,8 @@ jobs:
         # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
 
       - name: install frontend dependencies
-        run: yarn install # change this to npm, pnpm or bun depending on which one you use.
+        run: npm install
+        working-directory: ./installer
 
       - uses: tauri-apps/tauri-action@v0
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         if: matrix.platform == 'ubuntu-20.04' # This must match the platform value defined above.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
         # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
         # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,5 @@
 name: "publish"
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches:
       - release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: "publish"
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches:
+      - release
+
+# This is the example from the readme.
+# On each push to the `release` branch it will create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Intel based macs.
+            args: "--target x86_64-apple-darwin"
+          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ""
+          - platform: "windows-latest"
+            args: ""
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
+        # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
+
+      - name: install frontend dependencies
+        run: yarn install # change this to npm, pnpm or bun depending on which one you use.
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: "App v__VERSION__"
+          releaseBody: "See the assets to download this version and install."
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}
+          projectPath: ./installer

--- a/installer/src-tauri/build.rs
+++ b/installer/src-tauri/build.rs
@@ -110,39 +110,10 @@ fn compile_sketch(
     println!("Compiling sketch '{}'", sketch.to_str().unwrap_or_default());
 
     let output = Command::new(arduino_cli)
-        .args(&["core", "install", "arduino:mbed_nano"])
-        .output()?;
-    println!(
-        "core install output:\n{}\n{}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout),
-    );
-
-    let output = Command::new(arduino_cli)
-        .args(&[
-            "lib",
-            "install",
-            "Arduino_APDS9960",
-            "Arduino_HS300x",
-            "Arduino_LPS22HB",
-            "Arduino_BMI270_BMM150",
-            "Servo",
-            "ArduinoBLE",
-            "MsgPack",
-        ])
-        .output()?;
-    println!(
-        "lib install output:\n{}\n{}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout),
-    );
-
-    let output = Command::new(arduino_cli)
         .args(&[
             "compile",
-            "-b",
-            "arduino:mbed_nano:nano33ble",
-            "-e",
+            "--profile",
+            "nano33ble",
             sketch.to_str().unwrap(),
         ])
         .output()?;

--- a/installer/src-tauri/build.rs
+++ b/installer/src-tauri/build.rs
@@ -115,7 +115,7 @@ fn compile_sketch(
 
     println!("Compiling sketch '{}'", sketch.to_str().unwrap_or_default());
 
-    let profile = fqbn.rsplit('.').next().unwrap();
+    let profile = fqbn.rsplit(':').next().unwrap();
 
     let output = Command::new(arduino_cli)
         .args(&[
@@ -136,11 +136,16 @@ fn compile_sketch(
         return Err(anyhow::anyhow!("Compilation failed"));
     }
 
+    let path_fqbn: String = fqbn
+        .chars()
+        .map(|c| if c == ':' { '.' } else { c })
+        .collect();
+
     let dir = sketch.parent().unwrap();
     let file = sketch.file_name().unwrap();
     let bin = dir
         .join("build")
-        .join(fqbn)
+        .join(path_fqbn)
         .join(file)
         .with_extension("ino.bin");
 

--- a/installer/src-tauri/build.rs
+++ b/installer/src-tauri/build.rs
@@ -128,6 +128,7 @@ fn compile_sketch(
             "Arduino_BMI270_BMM150",
             "Servo",
             "ArduinoBLE",
+            "MsgPack",
         ])
         .output()?;
     println!(

--- a/installer/src-tauri/build.rs
+++ b/installer/src-tauri/build.rs
@@ -112,6 +112,7 @@ fn compile_sketch(
     let output = Command::new(arduino_cli)
         .args(&[
             "compile",
+            "-e",
             "--profile",
             "nano33ble",
             sketch.to_str().unwrap(),

--- a/installer/src-tauri/build.rs
+++ b/installer/src-tauri/build.rs
@@ -110,6 +110,33 @@ fn compile_sketch(
     println!("Compiling sketch '{}'", sketch.to_str().unwrap_or_default());
 
     let output = Command::new(arduino_cli)
+        .args(&["core", "install", "arduino:mbed_nano"])
+        .output()?;
+    println!(
+        "core install output:\n{}\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    let output = Command::new(arduino_cli)
+        .args(&[
+            "lib",
+            "install",
+            "Arduino_APDS9960",
+            "Arduino_HS300x",
+            "Arduino_LPS22HB",
+            "Arduino_BMI270_BMM150",
+            "Servo",
+            "ArduinoBLE",
+        ])
+        .output()?;
+    println!(
+        "lib install output:\n{}\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    let output = Command::new(arduino_cli)
         .args(&[
             "compile",
             "-b",
@@ -118,7 +145,6 @@ fn compile_sketch(
             sketch.to_str().unwrap(),
         ])
         .output()?;
-
     println!(
         "compilation output:\n{}\n{}",
         String::from_utf8_lossy(&output.stderr),

--- a/sketches/BLE_Scratch/sketch.yaml
+++ b/sketches/BLE_Scratch/sketch.yaml
@@ -1,0 +1,16 @@
+profiles:
+  nano33ble:
+    fqbn: arduino:mbed_nano:nano33ble
+    platforms:
+      - platform: arduino:mbed_nano (4.1.3)
+    libraries:
+      - Arduino_APDS9960 (1.0.4)
+      - Arduino_BMI270_BMM150 (1.2.0)
+      - Arduino_HS300x (1.0.0)
+      - Arduino_LPS22HB (1.0.2)
+      - ArduinoBLE (1.3.6)
+      - MsgPack (0.4.2)
+      - DebugLog (0.8.3)
+      - ArxTypeTraits (0.3.1)
+      - ArxContainer (0.6.0)
+      - Servo (1.2.1)


### PR DESCRIPTION
Use GitHub action to compile the installer for the most common OS and platform.

To trigger the release push a commit to the `release` branch.

This PR follows this [Tauri guide](https://tauri.app/v1/guides/building/cross-platform/) and uses [arduino-cli profile](https://blog.arduino.cc/2022/06/06/arduino-cli-0-23-makes-your-projects-future-proof-with-build-profiles/) for install all the sketches requirements.